### PR TITLE
Update Deploy SeaTable-DE with Docker.md

### DIFF
--- a/manual/docker/Developer-Edition/Deploy SeaTable-DE with Docker.md
+++ b/manual/docker/Developer-Edition/Deploy SeaTable-DE with Docker.md
@@ -80,9 +80,9 @@ Now you can start the SeaTable service.
 
 ```sh
 # Start SeaTable service.
-docker exec -d seatable /shared/seatable/scripts/seatable.sh start
+docker exec -d seatable //bin/bash /shared/seatable/scripts/seatable.sh start
 # Create an admin account.
-docker exec -it seatable /shared/seatable/scripts/seatable.sh superuser  
+docker exec -it seatable //bin/bash /shared/seatable/scripts/seatable.sh superuser  
 
 ```
 


### PR DESCRIPTION
Add `//bin/bash` in start-seatable commands. The original commands might cause ` OCI runtime exec failed: exec failed: container_linux.go:370: starting container process caused: permission denied: unknown` problem