### PR TITLE
build: build first, deploy on master

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,15 @@ jobs:
         with:
           python-version: 3.x
 
-      - run: |
-          pip install -r requirements.txt
-          mkdocs gh-deploy --force
+      - name: install
+        run: pip install -r requirements.txt
+
+      - name: version
+        run: mkdocs --version
+
+      - name: build
+        run: mkdocs build --strict --verbose
+
+      - name: gh-deploy
+        if: github.ref == 'refs/heads/master'
+        run: mkdocs gh-deploy --force


### PR DESCRIPTION
in a pull-request the deploy workflow is failing, always, as a pull-request
should not deploy - at least not to the repositories github page.

that is for a push to master.