### PR TITLE
add link to autostart in Installation instructions

### DIFF
--- a/manual/docker/Enterprise-Edition/Deploy SeaTable-EE with Docker.md
+++ b/manual/docker/Enterprise-Edition/Deploy SeaTable-EE with Docker.md
@@ -126,6 +126,8 @@ NOTE: The first command uses the option `-d` which starts the service in the bac
 
 You can now access SeaTable at the host name specified in the Compose file.
 
+NOTE: By default SeaTable will **not** start automatically. To complish this see the [documentation on autostart](https://manual.seatable.io/config/autostart/)
+
 ### Reviewing the Deployment
 
 The command `docker container list` should list the four containers specified in the `docker-compose.yml`:


### PR DESCRIPTION
Like most people I didn't read the full manual and just stopped after starting up the system. Of course I was surprised why after a restart, SeaTable isn't working. Reading further down in the manual the Autostart chapter sheds light into my problem.  Added a link to that chapter in the installation manual.