### PR TITLE
add automation-rules conf

### DIFF
--- a/docs/config/dtable-events-conf.md
+++ b/docs/config/dtable-events-conf.md
@@ -47,8 +47,20 @@ The configuration of notification rules scanner is in the `[NOTIFY-SCANNER]` sec
 ```
 [NOTIFY-SCANNER]
 enabled = true
-interval = 3600
 
 ```
 
+## Automation rules trigger configuration
+
+Automation rules is the feature that users can do some actions automatically for a base.
+
+The configuration of automation rules scanner is in the `[AUTOMATION]`
+
+In order to ensure server performance, automation rules cannot be triggered without limit. SeaTable provides a setting that limits the maximum number of triggers per rule per minute, default 50.
+
+```
+[AUTOMATION]
+per_minute_trigger_limit = 50
+
+```
 

--- a/docs/config/dtable-events-conf.md
+++ b/docs/config/dtable-events-conf.md
@@ -50,7 +50,7 @@ enabled = true
 
 ```
 
-## Automation rules trigger configuration
+## Automation rules configuration
 
 Automation rules is the feature that users can do some actions automatically for a base.
 

--- a/docs/config/dtable-events-conf.md
+++ b/docs/config/dtable-events-conf.md
@@ -50,17 +50,17 @@ enabled = true
 
 ```
 
-## Automation rules configuration
+## Automation Rules Configuration
 
-Automation rules is the feature that users can do some actions automatically for a base.
+In SeaTable, users have the ability to define triggers and actions within an automation rule.  
+These rules are then automatically executed on a base.
 
-The configuration of automation rules is in the `[AUTOMATION]`
+The settings for these automation rules are located within the `[AUTOMATION]` section of the `dtable-events.conf` file.
 
-In order to ensure server performance, automation rules cannot be triggered without limit. SeaTable provides a setting that limits the maximum number of triggers per rule per minute, default 50.
+
+To maintain server stability, SeaTable includes a feature that restricts the frequency of automation rule executions. This `per_minute_trigger_limit` is set to 50 by default.
 
 ```
 [AUTOMATION]
 per_minute_trigger_limit = 50
-
 ```
-

--- a/docs/config/dtable-events-conf.md
+++ b/docs/config/dtable-events-conf.md
@@ -54,7 +54,7 @@ enabled = true
 
 Automation rules is the feature that users can do some actions automatically for a base.
 
-The configuration of automation rules scanner is in the `[AUTOMATION]`
+The configuration of automation rules is in the `[AUTOMATION]`
 
 In order to ensure server performance, automation rules cannot be triggered without limit. SeaTable provides a setting that limits the maximum number of triggers per rule per minute, default 50.
 

--- a/docs/config/dtable-events-conf.md
+++ b/docs/config/dtable-events-conf.md
@@ -1,8 +1,8 @@
 # dtable-event.conf settings
 
-## Database configuration
+## Database Configuration
 
-The configuration of database is in the `[DATABASE]` section of the file `dtable-events.conf`
+The settings for the database connection are located in the `[DATABASE]` section of the file `dtable-events.conf`
 
 ```
 [DATABASE]
@@ -15,11 +15,11 @@ db_name = seafile_db
 
 ```
 
-Note: MariaDB and MySQL is compatible. In the configuration, we use mysql.
+Note: MariaDB and MySQL are compatible. In this configuration example, we use MySQL.
 
-## Redis configuration
+## Redis Configuration
 
-The configuration of redis is in the `[REDIS]` section of the file `dtable-events.conf`
+The settings for the Redis connection are located in the `[REDIS]` section of the file `dtable-events.conf`
 
 ```
 [REDIS]
@@ -28,9 +28,9 @@ port = 6379
 
 ```
 
-## Email notifications configuration
+## Email Notifications Configuration
 
-The configuration of email notifications is in the `[EMAIL SENDER]` section of the file `dtable-events.conf`
+The settings for email notifications are located in the `[EMAIL SENDER]` section of the file `dtable-events.conf`
 
 ```
 [EMAIL SENDER]
@@ -38,11 +38,11 @@ enabled = true
 
 ```
 
-## Notification rules scanner configuration
+## Notification Rules Scanner Configuration
 
-Notification rules is the feature that users can set notification rules for a base and got notifications when defined criteria meet.
+Notification rules are a feature that allows users to set criteria for a base and receive notifications when these criteria are met.
 
-The configuration of notification rules scanner is in the `[NOTIFY-SCANNER]` section of the file `dtable-events.conf`
+The settings for the notification rules scanner are located in the `[NOTIFY-SCANNER]` section of the file `dtable-events.conf`
 
 ```
 [NOTIFY-SCANNER]
@@ -55,7 +55,7 @@ enabled = true
 In SeaTable, users have the ability to define triggers and actions within an automation rule.  
 These rules are then automatically executed on a base.
 
-The settings for these automation rules are located within the `[AUTOMATION]` section of the `dtable-events.conf` file.
+The settings for the automation rules are located in the `[AUTOMATION]` section of the `dtable-events.conf` file.
 
 
 To maintain server stability, SeaTable includes a feature that restricts the frequency of automation rule executions. This `per_minute_trigger_limit` is set to 50 by default.


### PR DESCRIPTION
1. drop dtable-events [NOTIFY-SCANNER] `interval` setting because it is no longer supported
2. add [AUTOMATION] config section for automation-rules