### PR TITLE
Remove `/ping/` path mapping from `Caddyfile`

### DIFF
--- a/docs/installation/cluster/dtable-server-multiple.md
+++ b/docs/installation/cluster/dtable-server-multiple.md
@@ -183,7 +183,7 @@ Create `/opt/seatable-compose/dtable-server-proxy.yml` on `dtable-web`:
 
                     # Static paths are proxied to dtable-server:5000
                     @staticPaths {
-                            path /ping/ /api/v1/admin/sys-info/
+                            path /api/v1/admin/sys-info/
                     }
                     reverse_proxy @staticPaths dtable-server:5000
 


### PR DESCRIPTION
Administrators should rather ping each individual `dtable-server` instance.