### PR TITLE
Fix and complete the administrator roles documentation

### DIFF
--- a/docs/configuration/roles-and-permissions.md
+++ b/docs/configuration/roles-and-permissions.md
@@ -116,7 +116,9 @@ If you want to modify the permissions and quotas of either or both standard role
 
 ### Custom User Roles
 
-You can add additional user roles by extending the codeblock in `dtable_web_settings.py`.
+<!-- md:flag enterprise -->
+
+You can add additional user roles by extending the codeblock in `dtable_web_settings.py`. A custom user role inherits all permissions and quotas of the role `default`; you only need to list the values that shall differ.
 
 To add a role `employee`, for example, add the following lines (beginning at `'employee'` and ending at `},` ) to the existing role definition.
 
@@ -136,29 +138,101 @@ Restart SeaTable for the new role to become available in SeaTable.
 
 Similar to a user role, an administrator role is comprised of several permissions, but no quotas.
 
+!!! warning "Administrator permissions default to False"
+
+    User roles and administrator roles behave in opposite ways when a permission is not set: a user role grants everything that is not explicitly listed, an administrator role grants **nothing** that is not explicitly listed. Internally, every administrator role is merged onto a hidden role `dummy_admin` in which all permissions are set to `False`. Consequently, you must list every single permission that an administrator role shall have.
+
 ### Administrator Permissions
 
 The following permissions are supported in administrator roles:
 
-| Permission               | Added in version | Permission to ...                                                                             | Additional information |
-| ------------------------ | ---------------- | --------------------------------------------------------------------------------------------- | ---------------------- |
-| can_view_system_info     | 1.0              | See/access "Info" menu in System admin                                                        |                        |
-| can_view_statistic       | 1.0              | See/access "Statistic" menu in System admin                                                   |                        |
-| can_config_system        | 1.0              | See/access "Settings" menu in System admin                                                    |                        |
-| can_manage_user          | 1.0              | See/access "Users" menu in System admin                                                       |                        |
-| can_manage_group         | 1.0              | See/access "Groups" menu in System admin                                                      |                        |
-| can_manage_external_link | 1.0              | See/access "External links" menu in System admin                                              |                        |
-| can_view_admin_log       | 1.0              | See/access "Admin logs" menu in System admin                                                  |                        |
-| can_manage_user_log      | 1.0              | See/access the tab "Login logs" in "Audit logs" menu in System admin                          |                        |
-| can_manage_audit_log     | 1.0              | See/access the tabs "Action logs" and "File access logs" in "Audit logs" menu in System admin |                        |
-| can_manage_organization  | 1.0              | See/access "Organizations" menu in System admin                                               |                        |
+| Permission                  | Added in version | Permission to ...                                                                                        | Additional information                                                                                                                                                              |
+| --------------------------- | ---------------- | ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| can_view_system_info        | 1.0              | See/access "Info" menu in System admin                                                                   | The license cannot be uploaded with this permission alone.                                                                                                                          |
+| can_view_statistic          | 1.0              | See/access "Statistic" menu in System admin                                                              |                                                                                                                                                                                     |
+| can_config_system           | 1.0              | See/access "Settings" menu in System admin                                                               |                                                                                                                                                                                     |
+| can_manage_user             | 1.0              | See/access "Users" menu in System admin                                                                  |                                                                                                                                                                                     |
+| can_update_user             | 1.6              | See and modify the details of an individual user                                                         | Grants access to a single user account without granting the complete "Users" menu. An administrator with `can_manage_user` has these rights as well.                                 |
+| can_manage_group            | 1.0              | See/access "Groups" menu in System admin                                                                 |                                                                                                                                                                                     |
+| can_manage_external_link    | 1.0              | See/access "External links" menu in System admin                                                         |                                                                                                                                                                                     |
+| can_view_audit_log          | 5.1              | See/access "Audit logs" menu in System admin and its tabs "Action logs", "File access logs" and "Permission logs" | This permission controls the menu itself. Without it, the menu is hidden — even if `can_view_user_log` is set. The tabs besides "Login logs" additionally require the *user* permission `can_use_advanced_permissions`. |
+| can_view_user_log           | 1.0              | See/access the tabs "Login logs" and "Group member logs" in "Audit logs" menu in System admin             | Requires `can_view_audit_log` to make the menu visible.                                                                                                                             |
+| can_view_admin_log          | 1.0              | See/access "Admin logs" menu in System admin                                                             |                                                                                                                                                                                     |
+| can_manage_organization     | 2.0              | See/access "Organizations" menu in System admin                                                          | The menu is only shown if multi-tenancy is enabled.                                                                                                                                 |
+| can_update_organization     | 2.2              | See and modify the details of an individual organization                                                 | Grants access to a single organization without granting the complete "Organizations" menu. An administrator with `can_manage_organization` has these rights as well.                 |
+| can_manage_app              | 5.3              | See/access "Apps" menu in System admin                                                                   |                                                                                                                                                                                     |
+| other_permission            | 5.2              | See/access "Virus scan" menu in System admin                                                             | Despite its generic name, this permission currently only controls the virus scan records.                                                                                           |
+| can_manage_library          | 1.0              | Administer libraries via the API                                                                         | Inherited from Seafile. SeaTable's system administration has no "Libraries" menu, so this permission only guards the corresponding API endpoints.                                    |
+| can_manage_base             | 2.0              | Administer bases via the API                                                                             | The "Bases" menu is shown to the role `default_admin` only and cannot be granted to another role. This permission only guards the corresponding API endpoints.                       |
+| can_manage_form             | 2.0              | Administer forms via the API                                                                             | The "Forms" menu is shown to the role `default_admin` only and cannot be granted to another role. This permission only guards the corresponding API endpoints.                       |
+| can_manage_sys_notification | 2.0              | Administer system notifications via the API                                                              | The "Notifications" menu is shown to the role `default_admin` only and cannot be granted to another role. This permission only guards the corresponding API endpoints.               |
+| can_manage_plugin           | 2.0              | Administer plugins via the API                                                                           | The "Plugins" menu is shown to the role `default_admin` only and cannot be granted to another role. This permission only guards the corresponding API endpoints.                     |
 
+The default value for all permissions is False. This means that if a permission is not specifically set, the role does **not** grant the permission.
 
 ### Standard Administrator Roles
 
-SeaTable has four standard, preconfigured administrator roles `default admin`, `audit admin`, `daily admin` and `custom admin`. They can be used in the Users' section of the system administration without prior configuration.
+SeaTable has four standard, preconfigured administrator roles `default_admin`, `system_admin`, `daily_admin` and `audit_admin`. They can be used in the Users' section of the system administration without prior configuration.
+
+Only an administrator with the role `default_admin` can assign an administrator role to another administrator. All other administrator roles can see the role of an administrator, but not change it.
+
+The standard administrator roles are defined as follows:
+
+```python
+ENABLED_ADMIN_ROLE_PERMISSIONS = {
+    # can do everything
+    'default_admin': {
+        'can_view_system_info': True,
+        'can_view_statistic': True,
+        'can_config_system': True,
+        'can_manage_library': True,
+        'can_manage_user': True,
+        'can_update_user': True,
+        'can_manage_group': True,
+        'can_manage_external_link': True,
+        'can_view_user_log': True,
+        'can_view_audit_log': True,
+        'can_view_admin_log': True,
+        'can_manage_base': True,
+        'can_manage_app': True,
+        'can_manage_form': True,
+        'can_manage_organization': True,
+        'can_update_organization': True,
+        'can_manage_sys_notification': True,
+        'can_manage_plugin': True,
+        'other_permission': True,
+    },
+    # can ONLY access the "Info" and "Settings" menu
+    'system_admin': {
+        'can_view_system_info': True,
+        'can_config_system': True,
+    },
+    # can ONLY access the "Info", "Statistic", "Users", "Groups" and "Audit logs" menu
+    'daily_admin': {
+        'can_view_system_info': True,
+        'can_view_statistic': True,
+        'can_manage_library': True,
+        'can_manage_user': True,
+        'can_update_user': True,
+        'can_manage_group': True,
+        'can_view_user_log': True,
+        'can_view_audit_log': True,
+    },
+    # can ONLY access the "Info", "Audit logs" and "Admin logs" menu
+    'audit_admin': {
+        'can_view_system_info': True,
+        'can_view_admin_log': True,
+        'can_view_user_log': True,
+        'can_view_audit_log': True,
+    }
+}
+```
+
+If you want to modify the permissions of one or more standard administrator roles, copy-and-paste the above codeblock into `dtable_web_settings.py` and modify as per your needs. Restart SeaTable for the changes to take effect.
 
 ### Custom Administrator Roles
+
+<!-- md:flag enterprise -->
 
 Just like a user role, you can add additional administrator roles by adding/modifying the following codeblock in `dtable_web_settings.py`.
 
@@ -173,3 +247,11 @@ ENABLED_ADMIN_ROLE_PERMISSIONS = {
     }
 }
 ```
+
+Restart SeaTable for the new role to become available in SeaTable.
+
+!!! info "Custom roles are displayed with their technical name"
+
+    The four standard administrator roles (and the two standard user roles) have a translated display name in the web interface: `default_admin` is shown as "Default admin", `system_admin` as "System admin", `daily_admin` as "Daily admin" and `audit_admin` as "Audit admin".
+
+    For every other role, SeaTable falls back to the key you defined. A role `new_admin_role` therefore appears as `new_admin_role` in the role dropdown of the Users' section — underscores included. If you want a nice-looking entry, choose the key accordingly, e.g. `Support` instead of `support_admin_role`.


### PR DESCRIPTION
## Problem

The list of standard administrator roles named **`custom admin`** as the fourth preconfigured role. That role does not exist.

The fourth role is `system_admin`, displayed as "System admin" in the role dropdown of the Users' section. `custom_admin` is neither a constant in [`seahub/constants.py`](https://github.com/seafileltd/dtable-web/blob/master/seahub/constants.py#L46-L49) nor a key in `DEFAULT_ENABLED_ADMIN_ROLE_PERMISSIONS`. The only occurrence of that string anywhere in `dtable-web` is the local variable `custom_admin_role_permissions`, which holds the *custom* roles from `dtable_web_settings.py` — the opposite of a preconfigured role. The sentence "They can be used […] without prior configuration" therefore contradicted itself.

While verifying this against [`seahub/role_permissions/settings.py`](https://github.com/seafileltd/dtable-web/blob/master/seahub/role_permissions/settings.py), several further deviations turned up.

## Changes

**Standard roles.** All four are now named by their configuration key (`default_admin`, `system_admin`, `daily_admin`, `audit_admin`), with their actual definitions as a copy-and-paste codeblock — the same treatment the standard user roles already get.

**Permissions table, 10 → 19 rows.**

- `can_manage_user_log` and `can_manage_audit_log` never existed (code search: 0 hits). They are `can_view_user_log` and `can_view_audit_log`.
- Added: `can_update_user`, `can_manage_library`, `can_manage_base`, `can_manage_app`, `can_manage_form`, `can_update_organization`, `can_manage_sys_notification`, `can_manage_plugin`, `other_permission`.
- `can_manage_organization` was listed as 1.0; it arrived with seafileltd/dtable-web#1681 (2021-03-23) → 2.0.

**Three behaviours that were undocumented and regularly cause confusion:**

1. Administrator permissions default to **False** — the exact opposite of user permissions. Every admin role is merged onto the hidden `dummy_admin` role in which everything is `False`, so each wanted permission must be listed explicitly.
2. `can_manage_base`, `can_manage_form`, `can_manage_sys_notification`, `can_manage_plugin` and `can_manage_library` only guard API endpoints. The matching sidebar entries are gated by `isDefaultAdmin`, so "Bases", "Forms" etc. cannot be granted to any other role.
3. Only an administrator with the role `default_admin` may assign administrator roles (`admin_role.py:178`).

**Display names.** An info box explains that only the six standard roles have a translated label in `role-status-utils.js`; everything else falls through to `return role`. A custom role `new_admin_role` therefore appears verbatim — underscores included — in the dropdown. Since role keys are not validated beyond a membership check, picking `Support` as the key gives a clean label.

**Enterprise flag.** `<!-- md:flag enterprise -->` on both custom-role sections, where the `is_pro` check in `settings.py` silently discards `ENABLED_ROLE_PERMISSIONS` / `ENABLED_ADMIN_ROLE_PERMISSIONS` without a Pro license. Also noted that a custom user role inherits from `default`.

## Note on the version numbers

The older permissions could not be dated from a release list — changelog pages below 3.5 are no longer public. They were interpolated from the commit dates against the calibration points already present in the table (2021-03-25 → 2.0, 2021-06-18 → 2.2) and the published release dates:

| Permission | Commit | → Version |
| --- | --- | --- |
| `can_update_user` | 2020-12-16, immediately before "1.6.0 sql" (#1485) | 1.6 |
| `can_manage_base` / `_form` / `_organization` / `_sys_notification` / `_plugin` | 2021-03-23 (#1681) | 2.0 |
| `can_update_organization` | 2021-06-29 (#1943) | 2.2 |
| `can_view_audit_log` | 2024-08-19 (#4992), between 5.0.7 and 5.1.9 | 5.1 |
| `other_permission` | 2024-11-21 (#5066), between 5.1.9 and 5.2.7 | 5.2 |
| `can_manage_app` | 2025-04-08 (#5381), between 5.2.7 and 5.3.10 | 5.3 |

**1.6 and the 2.0 group are inferred, not sourced.** Worth a second look if an internal version/date list for 1.x and 2.x exists.

## Testing

- `python3 tests/validate_docs.py --strict` → 0 errors (3 warnings, all in unrelated files)
- `mkdocs build --strict` → builds clean; both admonitions and the Enterprise badges render

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DSukUw96UPeEwjXPAEQbzJ
